### PR TITLE
Add potted poise bush to vanilla's #flower_pots tag

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/flower_pots.json
+++ b/src/main/resources/data/minecraft/tags/blocks/flower_pots.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "endergetic:potted_poise_bush"
+  ]
+}


### PR DESCRIPTION
All vanilla potted plants and pretty much all modded potted plants are in this block tag, so it only makes sense to add this mod's potted plants.