### PR TITLE
Fixed all Corrock crash when in a modded dimension

### DIFF
--- a/src/main/java/endergeticexpansion/common/blocks/BlockCorrock.java
+++ b/src/main/java/endergeticexpansion/common/blocks/BlockCorrock.java
@@ -69,7 +69,7 @@ public class BlockCorrock extends Block implements IWaterLoggable {
 	@Override
 	public void tick(BlockState state, ServerWorld world, BlockPos pos, Random rand) {
 		if(!this.petrified && !this.isInProperDimension(world)) {
-			world.setBlockState(pos, CONVERSIONS.get(world.getDimension().getType()).get().getDefaultState());
+			world.setBlockState(pos, CONVERSIONS.getOrDefault(world.getDimension().getType(), EEBlocks.CORROCK_OVERWORLD).get().getDefaultState());
 		}
 	}
 	
@@ -107,7 +107,7 @@ public class BlockCorrock extends Block implements IWaterLoggable {
 	}
 
 	public boolean isInProperDimension(World world) {
-		return !this.petrified && CONVERSIONS.get(world.getDimension().getType()).get() == this;
+		return !this.petrified && CONVERSIONS.getOrDefault(world.getDimension().getType(), EEBlocks.CORROCK_OVERWORLD).get() == this;
 	}
 	
 	@Override

--- a/src/main/java/endergeticexpansion/common/blocks/BlockCorrockBlock.java
+++ b/src/main/java/endergeticexpansion/common/blocks/BlockCorrockBlock.java
@@ -48,7 +48,7 @@ public class BlockCorrockBlock extends Block {
 	@Override
 	public void tick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
 		if(!this.petrified && !this.isInProperDimension(world)) {
-			world.setBlockState(pos, CONVERSIONS.get(world.getDimension().getType()).get().getDefaultState());
+			world.setBlockState(pos, CONVERSIONS.getOrDefault(world.getDimension().getType(), EEBlocks.CORROCK_OVERWORLD_BLOCK).get().getDefaultState());
 		}
 	}
 	
@@ -79,7 +79,7 @@ public class BlockCorrockBlock extends Block {
 	}
 
 	public boolean isInProperDimension(World world) {
-		return !this.petrified && CONVERSIONS.get(world.getDimension().getType()).get() == this;
+		return !this.petrified && CONVERSIONS.getOrDefault(world.getDimension().getType(), EEBlocks.CORROCK_OVERWORLD_BLOCK).get() == this;
 	}
 	
 	public boolean isSubmerged(IWorld world, BlockPos pos) {

--- a/src/main/java/endergeticexpansion/common/blocks/BlockCorrockCrownStanding.java
+++ b/src/main/java/endergeticexpansion/common/blocks/BlockCorrockCrownStanding.java
@@ -37,7 +37,7 @@ import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.server.ServerWorld;
 
 public class BlockCorrockCrownStanding extends BlockCorrockCrown {
-	private static final Map<DimensionType, Supplier<Block>> CONVERSIONS = Util.make(Maps.newHashMap(), (conversions) -> {
+	private static final Map<DimensionType, Supplier<BlockCorrockCrown>> CONVERSIONS = Util.make(Maps.newHashMap(), (conversions) -> {
 		conversions.put(DimensionType.OVERWORLD, () -> EEBlocks.CORROCK_CROWN_OVERWORLD_STANDING.get());
 		conversions.put(DimensionType.THE_NETHER, () -> EEBlocks.CORROCK_CROWN_NETHER_STANDING.get());
 		conversions.put(DimensionType.THE_END, () -> EEBlocks.CORROCK_CROWN_END_STANDING.get());
@@ -58,7 +58,7 @@ public class BlockCorrockCrownStanding extends BlockCorrockCrown {
 	@Override
 	public void tick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
 		if(!this.petrified && !this.isInProperDimension(world)) {
-			world.setBlockState(pos, CONVERSIONS.get(world.getDimension().getType()).get().getDefaultState()
+			world.setBlockState(pos, CONVERSIONS.getOrDefault(world.getDimension().getType(), EEBlocks.CORROCK_CROWN_OVERWORLD_STANDING).get().getDefaultState()
 				.with(ROTATION, world.getBlockState(pos).get(ROTATION))
 				.with(UPSIDE_DOWN, world.getBlockState(pos).get(UPSIDE_DOWN))
 			);
@@ -99,7 +99,7 @@ public class BlockCorrockCrownStanding extends BlockCorrockCrown {
 	}
 	
 	public boolean isInProperDimension(World world) {
-		return !this.petrified && CONVERSIONS.get(world.getDimension().getType()).get() == this;
+		return !this.petrified && CONVERSIONS.getOrDefault(world.getDimension().getType(), EEBlocks.CORROCK_CROWN_OVERWORLD_STANDING).get() == this;
 	}
 	
 	public BlockState rotate(BlockState state, Rotation rot) {

--- a/src/main/java/endergeticexpansion/common/blocks/BlockCorrockCrownWall.java
+++ b/src/main/java/endergeticexpansion/common/blocks/BlockCorrockCrownWall.java
@@ -36,7 +36,7 @@ import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.server.ServerWorld;
 
 public class BlockCorrockCrownWall extends BlockCorrockCrown {
-	private static final Map<DimensionType, Supplier<Block>> CONVERSIONS = Util.make(Maps.newHashMap(), (conversions) -> {
+	private static final Map<DimensionType, Supplier<BlockCorrockCrownWall>> CONVERSIONS = Util.make(Maps.newHashMap(), (conversions) -> {
 		conversions.put(DimensionType.OVERWORLD, () -> EEBlocks.CORROCK_CROWN_OVERWORLD_WALL.get());
 		conversions.put(DimensionType.THE_NETHER, () -> EEBlocks.CORROCK_CROWN_NETHER_WALL.get());
 		conversions.put(DimensionType.THE_END, () -> EEBlocks.CORROCK_CROWN_END_WALL.get());
@@ -52,7 +52,7 @@ public class BlockCorrockCrownWall extends BlockCorrockCrown {
 	@Override
 	public void tick(BlockState state, ServerWorld world, BlockPos pos, Random random) {
 		if(!this.isInProperDimension(world)) {
-			world.setBlockState(pos, CONVERSIONS.get(world.getDimension().getType()).get().getDefaultState().with(FACING, world.getBlockState(pos).get(FACING)));
+			world.setBlockState(pos, CONVERSIONS.getOrDefault(world.getDimension().getType(), EEBlocks.CORROCK_CROWN_OVERWORLD_WALL).get().getDefaultState().with(FACING, world.getBlockState(pos).get(FACING)));
 		}
 	}
 	
@@ -108,7 +108,7 @@ public class BlockCorrockCrownWall extends BlockCorrockCrown {
 	}
 	
 	public boolean isInProperDimension(World world) {
-		return !this.petrified && CONVERSIONS.get(world.getDimension().getType()).get() == this;
+		return !this.petrified && CONVERSIONS.getOrDefault(world.getDimension().getType(), EEBlocks.CORROCK_CROWN_OVERWORLD_WALL).get() == this;
 	}
 
 	public BlockState rotate(BlockState state, Rotation rot) {


### PR DESCRIPTION
Resolves this bug report: https://github.com/minecraftabnormals/The-Endergetic-Expansion/issues/48#issuecomment-626096201

Right now, I wanted to just make the corrock keep their current behavior and only use their overworld form in modded dimensions as default. You can change the getOrDefault to computeIfAbsent and do some sort of check on the dimension to see if it is "end" like or "nether" like to determine variants.

However, I think the better method would be to check the biome that corrock is in for the biome type of NETHER or END for the variants. This can be done by changing isInProperDimension to take the blockpos too and then do `CONVERSION.getOrDefault(world.getBiome(blockpos).getCategory(), [default overworld block here])` and have the conversion basically use Biome.Category.THEEND and Biome.Category.NETHER as the key instead.

How you want to proceed is entirely up to you but for right now, this PR just deals with the crash with other mods. Good luck!