### PR TITLE
Add support for Savage & Ravage's growing and youth potions

### DIFF
--- a/src/main/java/endergeticexpansion/common/entities/booflo/EntityBooflo.java
+++ b/src/main/java/endergeticexpansion/common/entities/booflo/EntityBooflo.java
@@ -975,7 +975,34 @@ public class EntityBooflo extends EndimatedEntity {
 		}
 		this.setBoostPower(0.0F);
 	}
-	
+
+	public void growDown() {
+		if(!this.world.isRemote && this.isAlive()) {
+			EntityBoofloAdolescent boofloAdolescent = EEEntities.BOOFLO_ADOLESCENT.get().create(this.world);
+			boofloAdolescent.setLocationAndAngles(this.getPosX(), this.getPosY(), this.getPosZ(), this.rotationYaw, this.rotationPitch);
+
+			if(this.hasCustomName()) {
+				boofloAdolescent.setCustomName(this.getCustomName());
+				boofloAdolescent.setCustomNameVisible(this.isCustomNameVisible());
+			}
+
+			if(this.getLeashed()) {
+				boofloAdolescent.setLeashHolder(this.getLeashHolder(), true);
+				this.clearLeashed(true, false);
+			}
+
+			if(this.getRidingEntity() != null) {
+				boofloAdolescent.startRiding(this.getRidingEntity());
+			}
+
+			boofloAdolescent.wasBred = this.wasBred;
+			boofloAdolescent.setHealth(boofloAdolescent.getMaxHealth());
+			this.world.addEntity(boofloAdolescent);
+
+			this.remove();
+		}
+	}
+
 	public void catchPuffBug(EntityPuffBug puffbug) {
 		puffbug.startRiding(this, true);
 	}

--- a/src/main/java/endergeticexpansion/common/entities/booflo/EntityBoofloAdolescent.java
+++ b/src/main/java/endergeticexpansion/common/entities/booflo/EntityBoofloAdolescent.java
@@ -464,6 +464,33 @@ public class EntityBoofloAdolescent extends EndimatedEntity {
 			this.remove();
 		}
 	}
+
+	public void growDown() {
+		if(!this.world.isRemote && this.isAlive()) {
+			EntityBoofloBaby boofloBaby = EEEntities.BOOFLO_BABY.get().create(this.world);
+			boofloBaby.setLocationAndAngles(this.getPosX(), this.getPosY(), this.getPosZ(), this.rotationYaw, this.rotationPitch);
+
+			if(this.hasCustomName()) {
+				boofloBaby.setCustomName(this.getCustomName());
+				boofloBaby.setCustomNameVisible(this.isCustomNameVisible());
+			}
+
+			if(this.getLeashed()) {
+				boofloBaby.setLeashHolder(this.getLeashHolder(), true);
+				this.clearLeashed(true, false);
+			}
+
+			if(this.getRidingEntity() != null) {
+				boofloBaby.startRiding(this.getRidingEntity());
+			}
+
+			boofloBaby.wasBred = this.wasBred;
+			boofloBaby.setHealth(boofloBaby.getMaxHealth());
+			this.world.addEntity(boofloBaby);
+
+			this.remove();
+		}
+	}
 	
 	@OnlyIn(Dist.CLIENT)	
 	public float getTailAnimation(float ptc) {

--- a/src/main/java/endergeticexpansion/core/events/CompatEvents.java
+++ b/src/main/java/endergeticexpansion/core/events/CompatEvents.java
@@ -16,27 +16,21 @@ import net.minecraftforge.registries.ForgeRegistries;
  * Events for compatibility with the Savage & Ravage mod.
  */
 @Mod.EventBusSubscriber(modid = EndergeticExpansion.MOD_ID)
-public class SRCompatEvents {
+public class CompatEvents {
     @SubscribeEvent
     public static void onPotionExpire(PotionEvent.PotionExpiryEvent event) {
         LivingEntity affected = event.getEntityLiving();
         boolean isBabyEffect = event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:shrinking"));
-        
         if(isBabyEffect || event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:growth"))) {
-            
             if(!isBabyEffect && affected instanceof EntityBoofloBaby) ((EntityBoofloBaby)affected).growUp();
-            
             if(affected instanceof EntityBoofloAdolescent) {
-                
-                if (isBabyEffect) {
+                if(isBabyEffect) {
                     ((EntityBoofloAdolescent) affected).growDown();
                 } 
                 else {
                     ((EntityBoofloAdolescent) affected).growUp();
-               }
-                
+                }
             }
-            
             if(isBabyEffect && affected instanceof EntityBooflo) ((EntityBooflo)affected).growDown();
         }
 

--- a/src/main/java/endergeticexpansion/core/events/SRCompatEvents.java
+++ b/src/main/java/endergeticexpansion/core/events/SRCompatEvents.java
@@ -1,0 +1,37 @@
+package endergeticexpansion.core.events;
+
+import endergeticexpansion.common.entities.booflo.EntityBooflo;
+import endergeticexpansion.common.entities.booflo.EntityBoofloAdolescent;
+import endergeticexpansion.common.entities.booflo.EntityBoofloBaby;
+import endergeticexpansion.core.EndergeticExpansion;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.event.entity.living.PotionEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/**
+ * @author Voliant
+ * Events for compatibility with the Savage & Ravage mod.
+ */
+@Mod.EventBusSubscriber(modid = EndergeticExpansion.MOD_ID)
+public class SRCompatEvents {
+    @SubscribeEvent
+    public static void onPotionExpire(PotionEvent.PotionExpiryEvent event){
+        LivingEntity affected = event.getEntityLiving();
+        boolean isBabyEffect = event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:shrinking"));
+        if(isBabyEffect || event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:growth"))){
+            if(!isBabyEffect && affected instanceof EntityBoofloBaby) ((EntityBoofloBaby)affected).growUp();
+            if(affected instanceof EntityBoofloAdolescent) {
+                if (isBabyEffect) {
+                    ((EntityBoofloAdolescent) affected).growDown();
+                } else {
+                    ((EntityBoofloAdolescent) affected).growUp();
+                }
+            }
+            if(isBabyEffect && affected instanceof EntityBooflo) ((EntityBooflo)affected).growDown();
+        }
+
+    }
+}

--- a/src/main/java/endergeticexpansion/core/events/SRCompatEvents.java
+++ b/src/main/java/endergeticexpansion/core/events/SRCompatEvents.java
@@ -21,15 +21,22 @@ public class SRCompatEvents {
     public static void onPotionExpire(PotionEvent.PotionExpiryEvent event) {
         LivingEntity affected = event.getEntityLiving();
         boolean isBabyEffect = event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:shrinking"));
+        
         if(isBabyEffect || event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:growth"))) {
+            
             if(!isBabyEffect && affected instanceof EntityBoofloBaby) ((EntityBoofloBaby)affected).growUp();
+            
             if(affected instanceof EntityBoofloAdolescent) {
+                
                 if (isBabyEffect) {
                     ((EntityBoofloAdolescent) affected).growDown();
-                } else {
+                } 
+                else {
                     ((EntityBoofloAdolescent) affected).growUp();
-                }
+               }
+                
             }
+            
             if(isBabyEffect && affected instanceof EntityBooflo) ((EntityBooflo)affected).growDown();
         }
 

--- a/src/main/java/endergeticexpansion/core/events/SRCompatEvents.java
+++ b/src/main/java/endergeticexpansion/core/events/SRCompatEvents.java
@@ -18,10 +18,10 @@ import net.minecraftforge.registries.ForgeRegistries;
 @Mod.EventBusSubscriber(modid = EndergeticExpansion.MOD_ID)
 public class SRCompatEvents {
     @SubscribeEvent
-    public static void onPotionExpire(PotionEvent.PotionExpiryEvent event){
+    public static void onPotionExpire(PotionEvent.PotionExpiryEvent event) {
         LivingEntity affected = event.getEntityLiving();
         boolean isBabyEffect = event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:shrinking"));
-        if(isBabyEffect || event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:growth"))){
+        if(isBabyEffect || event.getPotionEffect().getPotion() == ForgeRegistries.POTIONS.getValue(new ResourceLocation("savageandravage:growth"))) {
             if(!isBabyEffect && affected instanceof EntityBoofloBaby) ((EntityBoofloBaby)affected).growUp();
             if(affected instanceof EntityBoofloAdolescent) {
                 if (isBabyEffect) {


### PR DESCRIPTION
The booflo can grow up, but does not extend `AgeableEntity` so it doesn't support S&R's potions by default. I've already added checks for the different booflo entities in particle creation methods on my end, but I'm pull requesting the actual growing into endergetic because it's much easier if i can create a `growDown` method and use `growUp` without indirection.