### PR TITLE
Update PuffBug.java `removeWhenFarAway` to avoid access to chunk data during spawn and despawn process.

### DIFF
--- a/src/main/java/com/teamabnormals/endergetic/common/entity/puffbug/PuffBug.java
+++ b/src/main/java/com/teamabnormals/endergetic/common/entity/puffbug/PuffBug.java
@@ -1102,7 +1102,7 @@ public class PuffBug extends Animal implements Endimatable {
 
 	@Override
 	public boolean removeWhenFarAway(double distanceToClosestPlayer) {
-		return this.getHive() == null && !this.isFromBottle() && !this.hasCustomName();
+		return this.getHivePos() == null && !this.isFromBottle() && !this.hasCustomName();
 	}
 
 	@Override


### PR DESCRIPTION
"Replaced `getHive()` with `getHivePose()` in `removeWhenFarAway` to prevent accessing chunk data during the spawn and despawn process.

This change will also slightly improve performance since `hivePose` is already checked regularly during tick events.   
See: [PuffBug.java#L217](https://github.com/team-abnormals/endergetic/blob/f49f630f5ecd3fb4ccd7a43de9347373b2a5087f/src/main/java/com/teamabnormals/endergetic/common/entity/puffbug/PuffBug.java#L217)