### PR TITLE
Backport Ender Wall Torch Particle Fix to 1.19.x

### DIFF
--- a/src/main/java/com/teamabnormals/endergetic/common/block/EnderWallTorchBlock.java
+++ b/src/main/java/com/teamabnormals/endergetic/common/block/EnderWallTorchBlock.java
@@ -4,13 +4,12 @@ import com.teamabnormals.endergetic.core.registry.EEParticleTypes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.WallTorchBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-
-import java.util.Random;
 
 public class EnderWallTorchBlock extends WallTorchBlock {
 
@@ -19,7 +18,8 @@ public class EnderWallTorchBlock extends WallTorchBlock {
 	}
 
 	@OnlyIn(Dist.CLIENT)
-	public void animateTick(BlockState stateIn, Level worldIn, BlockPos pos, Random rand) {
+	@Override
+	public void animateTick(BlockState stateIn, Level worldIn, BlockPos pos, RandomSource rand) {
 		Direction direction = stateIn.getValue(FACING);
 		double d0 = (double) pos.getX() + 0.5D;
 		double d1 = (double) pos.getY() + 0.7D;


### PR DESCRIPTION
Simple backport of the Wall Torch fix mentioned in https://github.com/team-abnormals/endergetic/issues/251, for 1.19.2 as that's what the issue reporter had asked about.