### PR TITLE
Fix Puff Bug AI crash (#295)

### DIFF
--- a/src/main/java/com/teamabnormals/endergetic/common/entity/puffbug/ai/PuffBugRotateToFireGoal.java
+++ b/src/main/java/com/teamabnormals/endergetic/common/entity/puffbug/ai/PuffBugRotateToFireGoal.java
@@ -83,9 +83,11 @@ public class PuffBugRotateToFireGoal extends Goal {
 
 		this.puffbug.getNavigation().stop();
 
-		Vec3 launchDirection = this.puffbug.getLaunchDirection();
+		if (this.puffbug.getLaunchDirection() != null) {
+			Vec3 launchDirection = this.puffbug.getLaunchDirection();
 
-		this.puffbug.getRotationController().rotate((float) Mth.wrapDegrees(launchDirection.y() - this.puffbug.getY()), (float) launchDirection.x() + 90.0F, 0.0F, 10);
+			this.puffbug.getRotationController().rotate((float) Mth.wrapDegrees(launchDirection.y() - this.puffbug.getY()), (float) launchDirection.x() + 90.0F, 0.0F, 10);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Addresses a crash that can occur occasionally from Puff Bugs, using a check similar to the one at <https://github.com/team-abnormals/endergetic/blob/1.20.x/src/main/java/com/teamabnormals/endergetic/common/entity/puffbug/ai/PuffBugRotateToFireGoal.java#L43>